### PR TITLE
Add tooltip with full stack count for clarity

### DIFF
--- a/src/main/java/com/lonkachu/configLoader.java
+++ b/src/main/java/com/lonkachu/configLoader.java
@@ -27,7 +27,7 @@ public class configLoader {
 
     private static Config configWriter() throws IOException {
         GsonBuilder b = new GsonBuilder();
-        Gson gson = b.create();
+        Gson gson = b.setPrettyPrinting().create();
         //gson.fieldNamingStrategy();
         FileWriter writer = new FileWriter("config/Stackable.json");
 

--- a/src/main/java/com/lonkachu/mixin/ToolTipMixin.java
+++ b/src/main/java/com/lonkachu/mixin/ToolTipMixin.java
@@ -1,0 +1,36 @@
+package com.lonkachu.mixin;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.tooltip.TooltipType;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
+
+/**
+ * @author fmp
+ */
+@Mixin(ItemStack.class)
+public abstract class ToolTipMixin {
+    /**
+     * Adds the full count in item tooltip.
+     * @author Devin-Kerman from stacc, updated for 1.21
+     */
+    @Inject(method = "getTooltip", at = @At("RETURN"))
+    private void addOverflowTooltip(Item.TooltipContext context, PlayerEntity player, TooltipType type, CallbackInfoReturnable<List<Text>> cir) {
+        if (this.getCount() > 999) {
+            List<Text> texts = cir.getReturnValue();
+            texts.add(1, Text.literal(String.valueOf(this.getCount())).formatted(Formatting.GRAY));
+        }
+    }
+
+    @Shadow
+    public abstract int getCount();
+}

--- a/src/main/resources/stackable.mixins.json
+++ b/src/main/resources/stackable.mixins.json
@@ -7,7 +7,8 @@
 		"DataComponentTypesFixin",
 		"InventoryStackMixin",
 		"ItemEntityMixin",
-		"ItemStackFixin"
+		"ItemStackFixin",
+		"ToolTipMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION
Borrows some code from an outdated mod called stacc-api which displays exact stack counts, which is one problem I had with the mod. They have some open source license so I think it should be fine, but it's not like this code is super innovative lol